### PR TITLE
Add WordCountAt method to KWG

### DIFF
--- a/kwg/kwg.go
+++ b/kwg/kwg.go
@@ -123,6 +123,10 @@ func (k *KWG) countWordsAt(p uint32) int {
 	return int(k.wordCounts[p])
 }
 
+func (k *KWG) WordCountAt(nodeIdx uint32) int32 {
+	return k.wordCounts[nodeIdx]
+}
+
 func (k *KWG) CountWords() {
 	k.wordCounts = make([]int32, len(k.nodes))
 	for p := len(k.wordCounts) - 1; p >= 0; p-- {

--- a/kwg/kwg.go
+++ b/kwg/kwg.go
@@ -123,6 +123,8 @@ func (k *KWG) countWordsAt(p uint32) int {
 	return int(k.wordCounts[p])
 }
 
+// WordCountAt returns the number of words in the subtree rooted at nodeIdx.
+// The caller must ensure CountWords has been called before using this method.
 func (k *KWG) WordCountAt(nodeIdx uint32) int32 {
 	return k.wordCounts[nodeIdx]
 }


### PR DESCRIPTION
## Summary
- Expose read access to the existing `wordCounts` slice via a new `WordCountAt` method on `KWG`
- Enables incremental KWG traversal for leave map population in Macondo (ported from magpie's `increment_node_to_ml`)

## Test plan
- [x] Verify `WordCountAt` returns correct counts after `CountWords` is called
- [x] Integrate in Macondo's leave map traversal and confirm O(1) leave value lookups

🤖 Generated with [Claude Code](https://claude.com/claude-code)