### PR TITLE
Expose KWG nodes slice and node bit-field constants

### DIFF
--- a/kwg/kwg.go
+++ b/kwg/kwg.go
@@ -95,6 +95,64 @@ func (k *KWG) Tile(nodeIdx uint32) uint8 {
 	return uint8(k.nodes[nodeIdx] >> 24)
 }
 
+// KWG node bit-field layout. Each node is a uint32:
+//
+//	bits  0..21  arc index (the link to the child node row)
+//	bit   22     end-of-arc-list flag (1 = last node in this arc list)
+//	bit   23     accepts flag (1 = path through this node spells a word)
+//	bits 24..31  tile letter (1..MAX_ALPHABET; 0 is unused)
+//
+// These constants are exported so a caller that has obtained the
+// underlying nodes slice via [KWG.Nodes] can decode each node
+// directly without having to call Tile/IsEnd/Accepts/ArcIndex four
+// separate times — useful in tight move-generator inner loops where
+// the same node value is used to read several bit fields back to
+// back.
+//
+// IMPORTANT: these constants describe the KWG layout only. [KBWG]
+// (the big word graph for huge alphabets) uses a different bit
+// layout — see KBWG's accessor methods. Don't use these constants
+// on a KBWG node value.
+const (
+	KWGNodeArcMask    uint32 = 0x3fffff
+	KWGNodeIsEndBit   uint32 = 0x400000
+	KWGNodeAcceptsBit uint32 = 0x800000
+	KWGNodeTileShift  uint32 = 24
+)
+
+// Nodes returns the underlying node array of this KWG. The returned
+// slice aliases internal state — callers must treat it as read-only.
+//
+// This is the fast path for tight inner loops that need to read
+// multiple bit fields out of the same node (Tile + IsEnd + Accepts +
+// ArcIndex). Without this accessor each of those four reads goes
+// through a separate method call and bounds-checked slice access
+// into the unexported k.nodes field; with the slice in hand the
+// caller can hoist the load and extract the bit fields locally:
+//
+//	nodes := k.Nodes()
+//	for i := startIdx; ; i++ {
+//	    node := nodes[i]
+//	    tile := uint8(node >> kwg.KWGNodeTileShift)
+//	    if tile == target {
+//	        arc := node & kwg.KWGNodeArcMask
+//	        accepts := node&kwg.KWGNodeAcceptsBit != 0
+//	        // ...
+//	        break
+//	    }
+//	    if node&kwg.KWGNodeIsEndBit != 0 {
+//	        break
+//	    }
+//	}
+//
+// In a move-generator profile, KWG.Tile and KWG.IsEnd combined for
+// roughly 18% of total CPU when called four-method-style; switching
+// to the hoisted-slice pattern collapses those entries and lets the
+// compiler keep the inner loop in registers.
+func (k *KWG) Nodes() []uint32 {
+	return k.nodes
+}
+
 // I have no idea what is going on in these functions. See wolges kwg.rs
 func (k *KWG) countWordsAt(p uint32) int {
 	if p >= uint32(len(k.wordCounts)) {


### PR DESCRIPTION
## Summary
- Add `KWG.Nodes()` accessor returning the underlying `[]uint32` (aliased, read-only) so callers can hoist a single node load in tight inner loops.
- Export `KWGNodeArcMask`, `KWGNodeIsEndBit`, `KWGNodeAcceptsBit`, `KWGNodeTileShift` so callers using `Nodes()` can decode the bit-field layout directly instead of going through four separate `Tile`/`IsEnd`/`Accepts`/`ArcIndex` method calls per node.
- Doc explicitly scopes the constants to `KWG` only — `KBWG` uses a different layout.

## Motivation
In a move-generator profile, the four-method-style decode (`Tile` + `IsEnd` + `Accepts` + `ArcIndex` on the same node) showed up around 18% of CPU. Hoisting the slice and extracting bit fields locally lets the compiler keep the inner loop in registers.

## Test plan
- [ ] `go build ./...`
- [ ] `go test ./kwg/...`
- [ ] Downstream move-generator builds against this branch and the hoisted-slice pattern compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)