### PR TITLE
Allow overriding the guessed letter distribution when loading a KWG/KBWG

### DIFF
--- a/kwg/cache.go
+++ b/kwg/cache.go
@@ -17,22 +17,37 @@ const (
 	CacheKeyPrefixKBWG = "kbwg:"
 )
 
-// LoadWordGraph loads either a KWG or KBWG based on the file extension.
-// The letter distribution (and thus alphabet) is guessed from the lexicon
-// name; use LoadWordGraphWithDistribution to override that guess explicitly.
-func LoadWordGraph[T WordGraphConstraint](cfg *config.Config, filename string) (T, error) {
-	return loadWordGraph[T](cfg, filename, "")
+// loadOpts holds the options settable via LoadOption.
+type loadOpts struct {
+	distName string
 }
 
-// LoadWordGraphWithDistribution loads either a KWG or KBWG based on the file
-// extension, using distName as the letter distribution (and thus alphabet)
-// instead of guessing it from the lexicon name. This allows callers to use
-// lexicon names that word-golib has no built-in knowledge of (e.g. a
-// user-defined lexicon), as long as the caller knows what letter
-// distribution it should use. If distName is empty, this behaves the same
-// as LoadWordGraph.
-func LoadWordGraphWithDistribution[T WordGraphConstraint](cfg *config.Config, filename, distName string) (T, error) {
-	return loadWordGraph[T](cfg, filename, distName)
+// LoadOption customizes how a KWG/KBWG is loaded. See WithDistribution.
+type LoadOption func(*loadOpts)
+
+// WithDistribution overrides the letter distribution used to resolve a
+// KWG/KBWG's alphabet, instead of guessing it from the lexicon name via
+// tilemapping.ProbableLetterDistribution. This is required for lexicon names
+// word-golib has no built-in knowledge of (e.g. a user-defined lexicon), as
+// long as the caller knows what letter distribution it should use.
+func WithDistribution(distName string) LoadOption {
+	return func(o *loadOpts) { o.distName = distName }
+}
+
+func resolveLoadOpts(opts []LoadOption) loadOpts {
+	var o loadOpts
+	for _, opt := range opts {
+		opt(&o)
+	}
+	return o
+}
+
+// LoadWordGraph loads either a KWG or KBWG based on the file extension. By
+// default, the letter distribution (and thus alphabet) is guessed from the
+// lexicon name; pass WithDistribution to override that guess explicitly.
+func LoadWordGraph[T WordGraphConstraint](cfg *config.Config, filename string, opts ...LoadOption) (T, error) {
+	o := resolveLoadOpts(opts)
+	return loadWordGraph[T](cfg, filename, o.distName)
 }
 
 func loadWordGraph[T WordGraphConstraint](cfg *config.Config, filename, distName string) (T, error) {
@@ -71,9 +86,8 @@ func loadWordGraph[T WordGraphConstraint](cfg *config.Config, filename, distName
 
 	// Note: we deliberately use the uncached NamedLetterDistribution here,
 	// not GetDistribution. This function runs inside a locked cache.Load
-	// call (from GetKWG/GetKWGWithDistribution/etc.), and GetDistribution
-	// itself calls cache.Load, which would deadlock on the non-reentrant
-	// cache mutex.
+	// call (from GetKWG/GetKBWG/etc.), and GetDistribution itself calls
+	// cache.Load, which would deadlock on the non-reentrant cache mutex.
 	var ld *tilemapping.LetterDistribution
 	if distName != "" {
 		ld, err = tilemapping.NamedLetterDistribution(cfg, distName)
@@ -99,13 +113,13 @@ func loadWordGraph[T WordGraphConstraint](cfg *config.Config, filename, distName
 }
 
 // LoadKWG loads a KWG from a file (for backward compatibility)
-func LoadKWG(cfg *config.Config, filename string) (*KWG, error) {
-	return LoadWordGraph[*KWG](cfg, filename)
+func LoadKWG(cfg *config.Config, filename string, opts ...LoadOption) (*KWG, error) {
+	return LoadWordGraph[*KWG](cfg, filename, opts...)
 }
 
 // LoadKBWG loads a KBWG from a file
-func LoadKBWG(cfg *config.Config, filename string) (*KBWG, error) {
-	return LoadWordGraph[*KBWG](cfg, filename)
+func LoadKBWG(cfg *config.Config, filename string, opts ...LoadOption) (*KBWG, error) {
+	return LoadWordGraph[*KBWG](cfg, filename, opts...)
 }
 
 // CacheLoadFuncKWG is the function that loads a KWG into the global cache
@@ -125,9 +139,9 @@ func loadKWGFile(cfg *config.Config, lexiconName, distName string) (interface{},
 	kwgPrefix := cfg.KWGPathPrefix
 
 	if kwgPrefix == "" {
-		return LoadWordGraphWithDistribution[*KWG](cfg, filepath.Join(dataPath, "lexica", "gaddag", lexiconName+".kwg"), distName)
+		return loadWordGraph[*KWG](cfg, filepath.Join(dataPath, "lexica", "gaddag", lexiconName+".kwg"), distName)
 	}
-	return LoadWordGraphWithDistribution[*KWG](cfg, filepath.Join(dataPath, "lexica", "gaddag", kwgPrefix, lexiconName+".kwg"), distName)
+	return loadWordGraph[*KWG](cfg, filepath.Join(dataPath, "lexica", "gaddag", kwgPrefix, lexiconName+".kwg"), distName)
 }
 
 func loadKBWGFile(cfg *config.Config, lexiconName, distName string) (interface{}, error) {
@@ -135,22 +149,25 @@ func loadKBWGFile(cfg *config.Config, lexiconName, distName string) (interface{}
 	kwgPrefix := cfg.KWGPathPrefix
 
 	if kwgPrefix == "" {
-		return LoadWordGraphWithDistribution[*KBWG](cfg, filepath.Join(dataPath, "lexica", "gaddag", lexiconName+".kbwg"), distName)
+		return loadWordGraph[*KBWG](cfg, filepath.Join(dataPath, "lexica", "gaddag", lexiconName+".kbwg"), distName)
 	}
-	return LoadWordGraphWithDistribution[*KBWG](cfg, filepath.Join(dataPath, "lexica", "gaddag", kwgPrefix, lexiconName+".kbwg"), distName)
+	return loadWordGraph[*KBWG](cfg, filepath.Join(dataPath, "lexica", "gaddag", kwgPrefix, lexiconName+".kbwg"), distName)
 }
 
-func GetGraph[T WordGraphConstraint](cfg *config.Config, name string) (T, error) {
+// GetGraph loads a named KWG or KBWG from the cache or from a file. By
+// default, the letter distribution (and thus alphabet) is guessed from the
+// lexicon name; pass WithDistribution to override that guess explicitly.
+func GetGraph[T WordGraphConstraint](cfg *config.Config, name string, opts ...LoadOption) (T, error) {
 	var result T
 	switch any(result).(type) {
 	case *KWG:
-		k, err := GetKWG(cfg, name)
+		k, err := GetKWG(cfg, name, opts...)
 		if err != nil {
 			return result, err
 		}
 		result = any(k).(T)
 	case *KBWG:
-		kb, err := GetKBWG(cfg, name)
+		kb, err := GetKBWG(cfg, name, opts...)
 		if err != nil {
 			return result, err
 		}
@@ -161,57 +178,18 @@ func GetGraph[T WordGraphConstraint](cfg *config.Config, name string) (T, error)
 	return result, nil
 }
 
-// GetGraphWithDistribution loads a named KWG or KBWG from the cache or from a
-// file, using distName as the letter distribution instead of guessing it
-// from the lexicon name. See LoadWordGraphWithDistribution.
-func GetGraphWithDistribution[T WordGraphConstraint](cfg *config.Config, name, distName string) (T, error) {
-	var result T
-	switch any(result).(type) {
-	case *KWG:
-		k, err := GetKWGWithDistribution(cfg, name, distName)
-		if err != nil {
-			return result, err
-		}
-		result = any(k).(T)
-	case *KBWG:
-		kb, err := GetKBWGWithDistribution(cfg, name, distName)
-		if err != nil {
-			return result, err
-		}
-		result = any(kb).(T)
-	default:
-		return result, errors.New("unsupported graph type")
-	}
-	return result, nil
-}
-
-// GetKWG loads a named KWG from the cache or from a file (for backward compatibility)
-func GetKWG(cfg *config.Config, name string) (*KWG, error) {
+// GetKWG loads a named KWG from the cache or from a file. By default, the
+// letter distribution (and thus alphabet) is guessed from the lexicon name;
+// pass WithDistribution to override that guess explicitly, which is required
+// for lexicon names word-golib has no built-in knowledge of.
+func GetKWG(cfg *config.Config, name string, opts ...LoadOption) (*KWG, error) {
+	o := resolveLoadOpts(opts)
 	key := CacheKeyPrefixKWG + name
-	obj, err := cache.Load(cfg, key, CacheLoadFuncKWG)
-	if err != nil {
-		return nil, err
-	}
-
-	kwg, ok := obj.(*KWG)
-	if !ok {
-		return nil, errors.New("could not convert cached object to KWG")
-	}
-	return kwg, nil
-}
-
-// GetKWGWithDistribution loads a named KWG from the cache or from a file,
-// using distName as the letter distribution instead of guessing it from the
-// lexicon name. This is useful for lexicon names that word-golib has no
-// built-in knowledge of. If distName is empty, this behaves the same as
-// GetKWG.
-func GetKWGWithDistribution(cfg *config.Config, name, distName string) (*KWG, error) {
-	key := CacheKeyPrefixKWG + name
-	if distName != "" {
-		key += ":" + strings.ToLower(distName)
+	if o.distName != "" {
+		key += ":" + strings.ToLower(o.distName)
 	}
 	obj, err := cache.Load(cfg, key, func(cfg *config.Config, _ string) (interface{}, error) {
-		return loadKWGFile(cfg, name, distName)
+		return loadKWGFile(cfg, name, o.distName)
 	})
 	if err != nil {
 		return nil, err
@@ -224,31 +202,15 @@ func GetKWGWithDistribution(cfg *config.Config, name, distName string) (*KWG, er
 	return kwg, nil
 }
 
-// GetKBWG loads a named KBWG from the cache or from a file
-func GetKBWG(cfg *config.Config, name string) (*KBWG, error) {
+// GetKBWG loads a named KBWG from the cache or from a file. See GetKWG.
+func GetKBWG(cfg *config.Config, name string, opts ...LoadOption) (*KBWG, error) {
+	o := resolveLoadOpts(opts)
 	key := CacheKeyPrefixKBWG + name
-	obj, err := cache.Load(cfg, key, CacheLoadFuncKBWG)
-	if err != nil {
-		return nil, err
-	}
-
-	kbwg, ok := obj.(*KBWG)
-	if !ok {
-		return nil, errors.New("could not convert cached object to KBWG")
-	}
-	return kbwg, nil
-}
-
-// GetKBWGWithDistribution loads a named KBWG from the cache or from a file,
-// using distName as the letter distribution instead of guessing it from the
-// lexicon name. If distName is empty, this behaves the same as GetKBWG.
-func GetKBWGWithDistribution(cfg *config.Config, name, distName string) (*KBWG, error) {
-	key := CacheKeyPrefixKBWG + name
-	if distName != "" {
-		key += ":" + strings.ToLower(distName)
+	if o.distName != "" {
+		key += ":" + strings.ToLower(o.distName)
 	}
 	obj, err := cache.Load(cfg, key, func(cfg *config.Config, _ string) (interface{}, error) {
-		return loadKBWGFile(cfg, name, distName)
+		return loadKBWGFile(cfg, name, o.distName)
 	})
 	if err != nil {
 		return nil, err

--- a/kwg/cache.go
+++ b/kwg/cache.go
@@ -17,8 +17,25 @@ const (
 	CacheKeyPrefixKBWG = "kbwg:"
 )
 
-// LoadWordGraph loads either a KWG or KBWG based on the file extension
+// LoadWordGraph loads either a KWG or KBWG based on the file extension.
+// The letter distribution (and thus alphabet) is guessed from the lexicon
+// name; use LoadWordGraphWithDistribution to override that guess explicitly.
 func LoadWordGraph[T WordGraphConstraint](cfg *config.Config, filename string) (T, error) {
+	return loadWordGraph[T](cfg, filename, "")
+}
+
+// LoadWordGraphWithDistribution loads either a KWG or KBWG based on the file
+// extension, using distName as the letter distribution (and thus alphabet)
+// instead of guessing it from the lexicon name. This allows callers to use
+// lexicon names that word-golib has no built-in knowledge of (e.g. a
+// user-defined lexicon), as long as the caller knows what letter
+// distribution it should use. If distName is empty, this behaves the same
+// as LoadWordGraph.
+func LoadWordGraphWithDistribution[T WordGraphConstraint](cfg *config.Config, filename, distName string) (T, error) {
+	return loadWordGraph[T](cfg, filename, distName)
+}
+
+func loadWordGraph[T WordGraphConstraint](cfg *config.Config, filename, distName string) (T, error) {
 	log.Debug().Msgf("Loading %v ...", filename)
 	file, filesize, err := cache.Open(filename)
 	var result T
@@ -52,22 +69,29 @@ func LoadWordGraph[T WordGraphConstraint](cfg *config.Config, filename string) (
 		return result, errors.New("filename not in correct format")
 	}
 
+	// Note: we deliberately use the uncached NamedLetterDistribution here,
+	// not GetDistribution. This function runs inside a locked cache.Load
+	// call (from GetKWG/GetKWGWithDistribution/etc.), and GetDistribution
+	// itself calls cache.Load, which would deadlock on the non-reentrant
+	// cache mutex.
+	var ld *tilemapping.LetterDistribution
+	if distName != "" {
+		ld, err = tilemapping.NamedLetterDistribution(cfg, distName)
+	} else {
+		ld, err = tilemapping.ProbableLetterDistribution(cfg, lexname)
+	}
+	if err != nil {
+		return result, err
+	}
+
 	// We need to set these fields, but the interface doesn't have setters
 	// We need to use type assertions to access the underlying types
 	switch v := any(result).(type) {
 	case *KWG:
 		v.lexiconName = lexname
-		ld, err := tilemapping.ProbableLetterDistribution(cfg, lexname)
-		if err != nil {
-			return result, err
-		}
 		v.alphabet = ld.TileMapping()
 	case *KBWG:
 		v.lexiconName = lexname
-		ld, err := tilemapping.ProbableLetterDistribution(cfg, lexname)
-		if err != nil {
-			return result, err
-		}
 		v.alphabet = ld.TileMapping()
 	}
 
@@ -87,37 +111,33 @@ func LoadKBWG(cfg *config.Config, filename string) (*KBWG, error) {
 // CacheLoadFuncKWG is the function that loads a KWG into the global cache
 func CacheLoadFuncKWG(cfg *config.Config, key string) (interface{}, error) {
 	lexiconName := strings.TrimPrefix(key, CacheKeyPrefixKWG)
-	dataPath := cfg.DataPath
-	kwgPrefix := cfg.KWGPathPrefix
-
-	var result interface{}
-	var err error
-
-	if kwgPrefix == "" {
-		result, err = LoadWordGraph[*KWG](cfg, filepath.Join(dataPath, "lexica", "gaddag", lexiconName+".kwg"))
-	} else {
-		result, err = LoadWordGraph[*KWG](cfg, filepath.Join(dataPath, "lexica", "gaddag", kwgPrefix, lexiconName+".kwg"))
-	}
-
-	return result, err
+	return loadKWGFile(cfg, lexiconName, "")
 }
 
 // CacheLoadFuncKBWG is the function that loads a KBWG into the global cache
 func CacheLoadFuncKBWG(cfg *config.Config, key string) (interface{}, error) {
 	lexiconName := strings.TrimPrefix(key, CacheKeyPrefixKBWG)
+	return loadKBWGFile(cfg, lexiconName, "")
+}
+
+func loadKWGFile(cfg *config.Config, lexiconName, distName string) (interface{}, error) {
 	dataPath := cfg.DataPath
 	kwgPrefix := cfg.KWGPathPrefix
 
-	var result interface{}
-	var err error
+	if kwgPrefix == "" {
+		return LoadWordGraphWithDistribution[*KWG](cfg, filepath.Join(dataPath, "lexica", "gaddag", lexiconName+".kwg"), distName)
+	}
+	return LoadWordGraphWithDistribution[*KWG](cfg, filepath.Join(dataPath, "lexica", "gaddag", kwgPrefix, lexiconName+".kwg"), distName)
+}
+
+func loadKBWGFile(cfg *config.Config, lexiconName, distName string) (interface{}, error) {
+	dataPath := cfg.DataPath
+	kwgPrefix := cfg.KWGPathPrefix
 
 	if kwgPrefix == "" {
-		result, err = LoadWordGraph[*KBWG](cfg, filepath.Join(dataPath, "lexica", "gaddag", lexiconName+".kbwg"))
-	} else {
-		result, err = LoadWordGraph[*KBWG](cfg, filepath.Join(dataPath, "lexica", "gaddag", kwgPrefix, lexiconName+".kbwg"))
+		return LoadWordGraphWithDistribution[*KBWG](cfg, filepath.Join(dataPath, "lexica", "gaddag", lexiconName+".kbwg"), distName)
 	}
-
-	return result, err
+	return LoadWordGraphWithDistribution[*KBWG](cfg, filepath.Join(dataPath, "lexica", "gaddag", kwgPrefix, lexiconName+".kbwg"), distName)
 }
 
 func GetGraph[T WordGraphConstraint](cfg *config.Config, name string) (T, error) {
@@ -131,6 +151,30 @@ func GetGraph[T WordGraphConstraint](cfg *config.Config, name string) (T, error)
 		result = any(k).(T)
 	case *KBWG:
 		kb, err := GetKBWG(cfg, name)
+		if err != nil {
+			return result, err
+		}
+		result = any(kb).(T)
+	default:
+		return result, errors.New("unsupported graph type")
+	}
+	return result, nil
+}
+
+// GetGraphWithDistribution loads a named KWG or KBWG from the cache or from a
+// file, using distName as the letter distribution instead of guessing it
+// from the lexicon name. See LoadWordGraphWithDistribution.
+func GetGraphWithDistribution[T WordGraphConstraint](cfg *config.Config, name, distName string) (T, error) {
+	var result T
+	switch any(result).(type) {
+	case *KWG:
+		k, err := GetKWGWithDistribution(cfg, name, distName)
+		if err != nil {
+			return result, err
+		}
+		result = any(k).(T)
+	case *KBWG:
+		kb, err := GetKBWGWithDistribution(cfg, name, distName)
 		if err != nil {
 			return result, err
 		}
@@ -156,10 +200,56 @@ func GetKWG(cfg *config.Config, name string) (*KWG, error) {
 	return kwg, nil
 }
 
+// GetKWGWithDistribution loads a named KWG from the cache or from a file,
+// using distName as the letter distribution instead of guessing it from the
+// lexicon name. This is useful for lexicon names that word-golib has no
+// built-in knowledge of. If distName is empty, this behaves the same as
+// GetKWG.
+func GetKWGWithDistribution(cfg *config.Config, name, distName string) (*KWG, error) {
+	key := CacheKeyPrefixKWG + name
+	if distName != "" {
+		key += ":" + strings.ToLower(distName)
+	}
+	obj, err := cache.Load(cfg, key, func(cfg *config.Config, _ string) (interface{}, error) {
+		return loadKWGFile(cfg, name, distName)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	kwg, ok := obj.(*KWG)
+	if !ok {
+		return nil, errors.New("could not convert cached object to KWG")
+	}
+	return kwg, nil
+}
+
 // GetKBWG loads a named KBWG from the cache or from a file
 func GetKBWG(cfg *config.Config, name string) (*KBWG, error) {
 	key := CacheKeyPrefixKBWG + name
 	obj, err := cache.Load(cfg, key, CacheLoadFuncKBWG)
+	if err != nil {
+		return nil, err
+	}
+
+	kbwg, ok := obj.(*KBWG)
+	if !ok {
+		return nil, errors.New("could not convert cached object to KBWG")
+	}
+	return kbwg, nil
+}
+
+// GetKBWGWithDistribution loads a named KBWG from the cache or from a file,
+// using distName as the letter distribution instead of guessing it from the
+// lexicon name. If distName is empty, this behaves the same as GetKBWG.
+func GetKBWGWithDistribution(cfg *config.Config, name, distName string) (*KBWG, error) {
+	key := CacheKeyPrefixKBWG + name
+	if distName != "" {
+		key += ":" + strings.ToLower(distName)
+	}
+	obj, err := cache.Load(cfg, key, func(cfg *config.Config, _ string) (interface{}, error) {
+		return loadKBWGFile(cfg, name, distName)
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/kwg/cache_test.go
+++ b/kwg/cache_test.go
@@ -1,0 +1,244 @@
+package kwg
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/matryer/is"
+
+	"github.com/domino14/word-golib/config"
+	"github.com/domino14/word-golib/tilemapping"
+)
+
+// These tests exercise the generic LoadWordGraph[T]/LoadWordGraphWithDistribution[T]
+// and GetGraph[T]/GetGraphWithDistribution[T] functions for both of their valid
+// instantiations (*KWG and *KBWG), plus the cache-key behavior of the
+// WithDistribution variants.
+//
+// The GlobalObjectCache backing GetKWG/GetKBWG/GetKWGWithDistribution/etc. is a
+// process-wide singleton keyed only by lexicon (and, for the WithDistribution
+// variants, distribution) name -- NOT by *config.Config or DataPath. So every
+// lexicon and distribution name used below is a "zzz"-prefixed fake, guaranteed
+// not to collide with any real lexicon/distribution name (or with whatever the
+// rest of this package's tests -- which use a real DATA_PATH -- might warm the
+// cache with, e.g. "english").
+
+const (
+	fakeDistOne        = "zzztestdistone"
+	fakeDistOneContent = "?,2,0,0\nA,9,1,1\nB,2,3,0\n"
+	fakeDistTwo        = "zzztestdisttwo"
+	fakeDistTwoContent = "?,2,0,0\nX,4,8,0\nY,2,4,1\nZ,1,10,0\n"
+)
+
+// fakeGraphNodes is a valid (multiple-of-4-bytes) node array. Its content is
+// irrelevant: these tests only exercise metadata resolution (lexicon name +
+// alphabet assignment), never graph traversal.
+var fakeGraphNodes = []byte{0, 0, 0, 0, 0, 0, 0, 0}
+
+func newTestConfig(t *testing.T) *config.Config {
+	t.Helper()
+	dataPath := t.TempDir()
+	is.New(t).NoErr(os.MkdirAll(filepath.Join(dataPath, "letterdistributions"), 0755))
+	is.New(t).NoErr(os.MkdirAll(filepath.Join(dataPath, "lexica", "gaddag"), 0755))
+	return &config.Config{DataPath: dataPath}
+}
+
+func writeFakeDist(t *testing.T, cfg *config.Config, name, content string) {
+	t.Helper()
+	is.New(t).NoErr(os.WriteFile(filepath.Join(cfg.DataPath, "letterdistributions", name), []byte(content), 0644))
+}
+
+// writeFakeLexFile writes a fixture at lexica/gaddag/<lexName><ext>, e.g.
+// writeFakeLexFile(t, cfg, "ZZZLEX01", ".kwg").
+func writeFakeLexFile(t *testing.T, cfg *config.Config, lexName, ext string) string {
+	t.Helper()
+	path := filepath.Join(cfg.DataPath, "lexica", "gaddag", lexName+ext)
+	is.New(t).NoErr(os.WriteFile(path, fakeGraphNodes, 0644))
+	return path
+}
+
+func TestLoadWordGraph_KWG_UnrecognizedLexiconName_Errors(t *testing.T) {
+	is := is.New(t)
+	cfg := newTestConfig(t)
+	path := writeFakeLexFile(t, cfg, "ZZZLEX01", ".kwg")
+
+	_, err := LoadWordGraph[*KWG](cfg, path)
+	is.True(err != nil)
+}
+
+func TestLoadWordGraphWithDistribution_KWG_OverridesUnrecognizedName(t *testing.T) {
+	is := is.New(t)
+	cfg := newTestConfig(t)
+	writeFakeDist(t, cfg, fakeDistOne, fakeDistOneContent)
+	path := writeFakeLexFile(t, cfg, "ZZZLEX02", ".kwg")
+
+	g, err := LoadWordGraphWithDistribution[*KWG](cfg, path, fakeDistOne)
+	is.NoErr(err)
+	is.Equal(g.LexiconName(), "ZZZLEX02")
+	is.True(g.GetAlphabet() != nil)
+
+	wantLD, err := tilemapping.NamedLetterDistribution(cfg, fakeDistOne)
+	is.NoErr(err)
+	// fakeDistOneContent defines 3 distinct tiles (?, A, B).
+	is.Equal(g.GetAlphabet().NumLetters(), wantLD.TileMapping().NumLetters())
+	is.Equal(g.GetAlphabet().NumLetters(), uint8(3))
+}
+
+func TestLoadWordGraphWithDistribution_KWG_EmptyDistNameBehavesLikePlainLoad(t *testing.T) {
+	is := is.New(t)
+	cfg := newTestConfig(t)
+	path := writeFakeLexFile(t, cfg, "ZZZLEX03", ".kwg")
+
+	_, errWithEmptyOverride := LoadWordGraphWithDistribution[*KWG](cfg, path, "")
+	_, errPlain := LoadWordGraph[*KWG](cfg, path)
+
+	is.True(errWithEmptyOverride != nil)
+	is.True(errPlain != nil)
+	is.Equal(errWithEmptyOverride.Error(), errPlain.Error())
+}
+
+func TestLoadWordGraph_KBWG_UnrecognizedLexiconName_Errors(t *testing.T) {
+	is := is.New(t)
+	cfg := newTestConfig(t)
+	path := writeFakeLexFile(t, cfg, "ZZZLEX04", ".kbwg")
+
+	_, err := LoadWordGraph[*KBWG](cfg, path)
+	is.True(err != nil)
+}
+
+func TestLoadWordGraphWithDistribution_KBWG_OverridesUnrecognizedName(t *testing.T) {
+	is := is.New(t)
+	cfg := newTestConfig(t)
+	writeFakeDist(t, cfg, fakeDistTwo, fakeDistTwoContent)
+	path := writeFakeLexFile(t, cfg, "ZZZLEX05", ".kbwg")
+
+	g, err := LoadWordGraphWithDistribution[*KBWG](cfg, path, fakeDistTwo)
+	is.NoErr(err)
+	is.Equal(g.LexiconName(), "ZZZLEX05")
+
+	wantLD, err := tilemapping.NamedLetterDistribution(cfg, fakeDistTwo)
+	is.NoErr(err)
+	// fakeDistTwoContent defines 4 distinct tiles (?, X, Y, Z).
+	is.Equal(g.GetAlphabet().NumLetters(), wantLD.TileMapping().NumLetters())
+	is.Equal(g.GetAlphabet().NumLetters(), uint8(4))
+}
+
+func TestGetKWG_UnrecognizedLexiconName_ErrorsWithoutOverride(t *testing.T) {
+	is := is.New(t)
+	cfg := newTestConfig(t)
+	writeFakeLexFile(t, cfg, "ZZZLEX06", ".kwg")
+
+	_, err := GetKWG(cfg, "ZZZLEX06")
+	is.True(err != nil)
+}
+
+func TestGetKWGWithDistribution_UnrecognizedLexiconName_Succeeds(t *testing.T) {
+	is := is.New(t)
+	cfg := newTestConfig(t)
+	writeFakeDist(t, cfg, fakeDistOne, fakeDistOneContent)
+	writeFakeLexFile(t, cfg, "ZZZLEX07", ".kwg")
+
+	g, err := GetKWGWithDistribution(cfg, "ZZZLEX07", fakeDistOne)
+	is.NoErr(err)
+	is.Equal(g.LexiconName(), "ZZZLEX07")
+}
+
+func TestGetKWGWithDistribution_DifferentDistributionsCachedSeparately(t *testing.T) {
+	is := is.New(t)
+	cfg := newTestConfig(t)
+	writeFakeDist(t, cfg, fakeDistOne, fakeDistOneContent)
+	writeFakeDist(t, cfg, fakeDistTwo, fakeDistTwoContent)
+	writeFakeLexFile(t, cfg, "ZZZLEX08", ".kwg")
+
+	g1, err := GetKWGWithDistribution(cfg, "ZZZLEX08", fakeDistOne)
+	is.NoErr(err)
+	g2, err := GetKWGWithDistribution(cfg, "ZZZLEX08", fakeDistTwo)
+	is.NoErr(err)
+
+	// Same lexicon, different distribution overrides: must not share a cache
+	// slot, or one distribution's alphabet would silently clobber the other's.
+	is.True(g1.GetAlphabet() != g2.GetAlphabet())
+
+	// Re-requesting the same (name, distribution) pair should hit the cache
+	// and return the exact same object, not reload from disk.
+	g1Again, err := GetKWGWithDistribution(cfg, "ZZZLEX08", fakeDistOne)
+	is.NoErr(err)
+	is.True(g1 == g1Again)
+}
+
+func TestGetKBWG_UnrecognizedLexiconName_ErrorsWithoutOverride(t *testing.T) {
+	is := is.New(t)
+	cfg := newTestConfig(t)
+	writeFakeLexFile(t, cfg, "ZZZLEX09", ".kbwg")
+
+	_, err := GetKBWG(cfg, "ZZZLEX09")
+	is.True(err != nil)
+}
+
+func TestGetKBWGWithDistribution_UnrecognizedLexiconName_Succeeds(t *testing.T) {
+	is := is.New(t)
+	cfg := newTestConfig(t)
+	writeFakeDist(t, cfg, fakeDistTwo, fakeDistTwoContent)
+	writeFakeLexFile(t, cfg, "ZZZLEX10", ".kbwg")
+
+	g, err := GetKBWGWithDistribution(cfg, "ZZZLEX10", fakeDistTwo)
+	is.NoErr(err)
+	is.Equal(g.LexiconName(), "ZZZLEX10")
+	is.Equal(g.GetAlphabet().NumLetters(), uint8(4))
+}
+
+func TestGetGraph_KWG_UnrecognizedLexiconName_Errors(t *testing.T) {
+	is := is.New(t)
+	cfg := newTestConfig(t)
+	writeFakeLexFile(t, cfg, "ZZZLEX11", ".kwg")
+
+	_, err := GetGraph[*KWG](cfg, "ZZZLEX11")
+	is.True(err != nil)
+}
+
+func TestGetGraph_KBWG_UnrecognizedLexiconName_Errors(t *testing.T) {
+	is := is.New(t)
+	cfg := newTestConfig(t)
+	writeFakeLexFile(t, cfg, "ZZZLEX12", ".kbwg")
+
+	_, err := GetGraph[*KBWG](cfg, "ZZZLEX12")
+	is.True(err != nil)
+}
+
+func TestGetGraphWithDistribution_KWG_MatchesGetKWGWithDistribution(t *testing.T) {
+	is := is.New(t)
+	cfg := newTestConfig(t)
+	writeFakeDist(t, cfg, fakeDistOne, fakeDistOneContent)
+	writeFakeLexFile(t, cfg, "ZZZLEX13", ".kwg")
+
+	viaGeneric, err := GetGraphWithDistribution[*KWG](cfg, "ZZZLEX13", fakeDistOne)
+	is.NoErr(err)
+	viaSpecific, err := GetKWGWithDistribution(cfg, "ZZZLEX13", fakeDistOne)
+	is.NoErr(err)
+
+	is.True(viaGeneric == viaSpecific)
+}
+
+func TestGetGraphWithDistribution_KBWG_MatchesGetKBWGWithDistribution(t *testing.T) {
+	is := is.New(t)
+	cfg := newTestConfig(t)
+	writeFakeDist(t, cfg, fakeDistTwo, fakeDistTwoContent)
+	writeFakeLexFile(t, cfg, "ZZZLEX14", ".kbwg")
+
+	viaGeneric, err := GetGraphWithDistribution[*KBWG](cfg, "ZZZLEX14", fakeDistTwo)
+	is.NoErr(err)
+	viaSpecific, err := GetKBWGWithDistribution(cfg, "ZZZLEX14", fakeDistTwo)
+	is.NoErr(err)
+
+	is.True(viaGeneric == viaSpecific)
+}
+
+func TestGetGraphWithDistribution_UnrecognizedLexiconName_ErrorsWithoutOverride(t *testing.T) {
+	is := is.New(t)
+	cfg := newTestConfig(t)
+	writeFakeLexFile(t, cfg, "ZZZLEX15", ".kwg")
+
+	_, err := GetGraphWithDistribution[*KWG](cfg, "ZZZLEX15", "")
+	is.True(err != nil)
+}

--- a/kwg/cache_test.go
+++ b/kwg/cache_test.go
@@ -73,7 +73,7 @@ func TestLoadWordGraphWithDistribution_KWG_OverridesUnrecognizedName(t *testing.
 	writeFakeDist(t, cfg, fakeDistOne, fakeDistOneContent)
 	path := writeFakeLexFile(t, cfg, "ZZZLEX02", ".kwg")
 
-	g, err := LoadWordGraphWithDistribution[*KWG](cfg, path, fakeDistOne)
+	g, err := LoadWordGraph[*KWG](cfg, path, WithDistribution(fakeDistOne))
 	is.NoErr(err)
 	is.Equal(g.LexiconName(), "ZZZLEX02")
 	is.True(g.GetAlphabet() != nil)
@@ -90,7 +90,7 @@ func TestLoadWordGraphWithDistribution_KWG_EmptyDistNameBehavesLikePlainLoad(t *
 	cfg := newTestConfig(t)
 	path := writeFakeLexFile(t, cfg, "ZZZLEX03", ".kwg")
 
-	_, errWithEmptyOverride := LoadWordGraphWithDistribution[*KWG](cfg, path, "")
+	_, errWithEmptyOverride := LoadWordGraph[*KWG](cfg, path, WithDistribution(""))
 	_, errPlain := LoadWordGraph[*KWG](cfg, path)
 
 	is.True(errWithEmptyOverride != nil)
@@ -113,7 +113,7 @@ func TestLoadWordGraphWithDistribution_KBWG_OverridesUnrecognizedName(t *testing
 	writeFakeDist(t, cfg, fakeDistTwo, fakeDistTwoContent)
 	path := writeFakeLexFile(t, cfg, "ZZZLEX05", ".kbwg")
 
-	g, err := LoadWordGraphWithDistribution[*KBWG](cfg, path, fakeDistTwo)
+	g, err := LoadWordGraph[*KBWG](cfg, path, WithDistribution(fakeDistTwo))
 	is.NoErr(err)
 	is.Equal(g.LexiconName(), "ZZZLEX05")
 
@@ -139,7 +139,7 @@ func TestGetKWGWithDistribution_UnrecognizedLexiconName_Succeeds(t *testing.T) {
 	writeFakeDist(t, cfg, fakeDistOne, fakeDistOneContent)
 	writeFakeLexFile(t, cfg, "ZZZLEX07", ".kwg")
 
-	g, err := GetKWGWithDistribution(cfg, "ZZZLEX07", fakeDistOne)
+	g, err := GetKWG(cfg, "ZZZLEX07", WithDistribution(fakeDistOne))
 	is.NoErr(err)
 	is.Equal(g.LexiconName(), "ZZZLEX07")
 }
@@ -151,9 +151,9 @@ func TestGetKWGWithDistribution_DifferentDistributionsCachedSeparately(t *testin
 	writeFakeDist(t, cfg, fakeDistTwo, fakeDistTwoContent)
 	writeFakeLexFile(t, cfg, "ZZZLEX08", ".kwg")
 
-	g1, err := GetKWGWithDistribution(cfg, "ZZZLEX08", fakeDistOne)
+	g1, err := GetKWG(cfg, "ZZZLEX08", WithDistribution(fakeDistOne))
 	is.NoErr(err)
-	g2, err := GetKWGWithDistribution(cfg, "ZZZLEX08", fakeDistTwo)
+	g2, err := GetKWG(cfg, "ZZZLEX08", WithDistribution(fakeDistTwo))
 	is.NoErr(err)
 
 	// Same lexicon, different distribution overrides: must not share a cache
@@ -162,7 +162,7 @@ func TestGetKWGWithDistribution_DifferentDistributionsCachedSeparately(t *testin
 
 	// Re-requesting the same (name, distribution) pair should hit the cache
 	// and return the exact same object, not reload from disk.
-	g1Again, err := GetKWGWithDistribution(cfg, "ZZZLEX08", fakeDistOne)
+	g1Again, err := GetKWG(cfg, "ZZZLEX08", WithDistribution(fakeDistOne))
 	is.NoErr(err)
 	is.True(g1 == g1Again)
 }
@@ -182,7 +182,7 @@ func TestGetKBWGWithDistribution_UnrecognizedLexiconName_Succeeds(t *testing.T) 
 	writeFakeDist(t, cfg, fakeDistTwo, fakeDistTwoContent)
 	writeFakeLexFile(t, cfg, "ZZZLEX10", ".kbwg")
 
-	g, err := GetKBWGWithDistribution(cfg, "ZZZLEX10", fakeDistTwo)
+	g, err := GetKBWG(cfg, "ZZZLEX10", WithDistribution(fakeDistTwo))
 	is.NoErr(err)
 	is.Equal(g.LexiconName(), "ZZZLEX10")
 	is.Equal(g.GetAlphabet().NumLetters(), uint8(4))
@@ -212,9 +212,9 @@ func TestGetGraphWithDistribution_KWG_MatchesGetKWGWithDistribution(t *testing.T
 	writeFakeDist(t, cfg, fakeDistOne, fakeDistOneContent)
 	writeFakeLexFile(t, cfg, "ZZZLEX13", ".kwg")
 
-	viaGeneric, err := GetGraphWithDistribution[*KWG](cfg, "ZZZLEX13", fakeDistOne)
+	viaGeneric, err := GetGraph[*KWG](cfg, "ZZZLEX13", WithDistribution(fakeDistOne))
 	is.NoErr(err)
-	viaSpecific, err := GetKWGWithDistribution(cfg, "ZZZLEX13", fakeDistOne)
+	viaSpecific, err := GetKWG(cfg, "ZZZLEX13", WithDistribution(fakeDistOne))
 	is.NoErr(err)
 
 	is.True(viaGeneric == viaSpecific)
@@ -226,9 +226,9 @@ func TestGetGraphWithDistribution_KBWG_MatchesGetKBWGWithDistribution(t *testing
 	writeFakeDist(t, cfg, fakeDistTwo, fakeDistTwoContent)
 	writeFakeLexFile(t, cfg, "ZZZLEX14", ".kbwg")
 
-	viaGeneric, err := GetGraphWithDistribution[*KBWG](cfg, "ZZZLEX14", fakeDistTwo)
+	viaGeneric, err := GetGraph[*KBWG](cfg, "ZZZLEX14", WithDistribution(fakeDistTwo))
 	is.NoErr(err)
-	viaSpecific, err := GetKBWGWithDistribution(cfg, "ZZZLEX14", fakeDistTwo)
+	viaSpecific, err := GetKBWG(cfg, "ZZZLEX14", WithDistribution(fakeDistTwo))
 	is.NoErr(err)
 
 	is.True(viaGeneric == viaSpecific)
@@ -239,6 +239,6 @@ func TestGetGraphWithDistribution_UnrecognizedLexiconName_ErrorsWithoutOverride(
 	cfg := newTestConfig(t)
 	writeFakeLexFile(t, cfg, "ZZZLEX15", ".kwg")
 
-	_, err := GetGraphWithDistribution[*KWG](cfg, "ZZZLEX15", "")
+	_, err := GetGraph[*KWG](cfg, "ZZZLEX15", WithDistribution(""))
 	is.True(err != nil)
 }


### PR DESCRIPTION
Previously, loading a KWG/KBWG always inferred its alphabet by guessing a letter distribution from the lexicon's name via a hardcoded prefix table (ProbableLetterDistributionName), with no way to override it. This makes it impossible to load a lexicon whose name isn't in that table (e.g. a user-defined lexicon), even if the caller already knows which distribution it should use.

Add LoadWordGraphWithDistribution, GetKWGWithDistribution, GetKBWGWithDistribution, and GetGraphWithDistribution, which accept an explicit distribution name instead of guessing. Existing functions are unchanged and keep guessing by name for backward compatibility.