### PR TITLE
Add SLV26 (Slovene) to the letter distribution prefix guesser

### DIFF
--- a/tilemapping/letter_distribution.go
+++ b/tilemapping/letter_distribution.go
@@ -157,6 +157,7 @@ func ProbableLetterDistributionName(lexname string) (string, error) {
 		"fise":    "spanish",
 		"file":    "spanish",
 		"dsw":     "dutch",
+		"slv":     "slovene",
 	}
 	for prefix, name := range prefixMap {
 		if strings.HasPrefix(lexname, prefix) {

--- a/tilemapping/letter_distribution_test.go
+++ b/tilemapping/letter_distribution_test.go
@@ -32,3 +32,26 @@ func TestLetterDistributionWordScore(t *testing.T) {
 	is.NoErr(err)
 	is.Equal(ld.WordScore(mls), 11)
 }
+
+func TestProbableLetterDistributionName(t *testing.T) {
+	is := is.New(t)
+
+	cases := []struct {
+		lexname string
+		want    string
+	}{
+		{"SLV26", "slovene"},
+		{"slv26", "slovene"},
+		{"NWL23", "english"},
+		{"CSW24", "english"},
+		{"OSPS50", "polish"},
+	}
+	for _, c := range cases {
+		got, err := ProbableLetterDistributionName(c.lexname)
+		is.NoErr(err)
+		is.Equal(got, c.want)
+	}
+
+	_, err := ProbableLetterDistributionName("WOW24")
+	is.True(err != nil)
+}


### PR DESCRIPTION
Maps lexicon names prefixed "slv" (e.g. SLV26) to the "slovene" letter distribution in ProbableLetterDistributionName, the same way NWL23/CSW24 map to "english". The actual slovene letter-distribution data file is data (lives outside this repo, alongside the other letterdistributions/* files) and isn't added here.